### PR TITLE
Add missing 'metatiles32x32' reference to game resources files

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,6 +256,8 @@ game.resources = [
      */
     // our level tileset
     {name: "area01_level_tiles",  type:"image", src: "data/img/map/area01_level_tiles.png"},
+    // our metatiles
+    {name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
     
     /* 
      * Maps. 
@@ -341,6 +343,8 @@ game.resources = [{
      */
     // our level tileset
     {name: "area01_level_tiles", type:"image", src: "data/img/map/area01_level_tiles.png"},
+    // our metatiles
+    {name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
     // the main player spritesheet
     {name: "gripe_run_right", type:"image", src: "data/img/sprite/gripe_run_right.png"},
     /* 
@@ -572,6 +576,8 @@ game.resources = [
      */
     // our level tileset
     {name: "area01_level_tiles",  type:"image", src: "data/img/map/area01_level_tiles.png"},
+    // our metatiles
+    {name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
     // the main player spritesheet
     {name: "gripe_run_right",     type:"image", src: "data/img/sprite/gripe_run_right.png"},
     // the parallax background
@@ -632,6 +638,8 @@ game.resources = [
      */
     // our level tileset
     {name: "area01_level_tiles",  type:"image", src: "data/img/map/area01_level_tiles.png"},
+    // our metatiles
+    {name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
     // the main player spritesheet
     {name: "gripe_run_right",     type:"image", src: "data/img/sprite/gripe_run_right.png"},
     // the parallax background
@@ -897,6 +905,8 @@ game.resources = [
      */
     // our level tileset
     {name: "area01_level_tiles",  type:"image", src: "data/img/map/area01_level_tiles.png"},
+    // our metatiles
+    {name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
     // the main player spritesheet
     {name: "gripe_run_right",     type:"image", src: "data/img/sprite/gripe_run_right.png"},
     // the parallax background
@@ -1140,6 +1150,8 @@ game.resources = [
      */
     // our level tileset
     {name: "area01_level_tiles",  type:"image", src: "data/img/map/area01_level_tiles.png"},
+    // our metatiles
+    {name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
     // the main player spritesheet
     {name: "gripe_run_right",     type:"image", src: "data/img/sprite/gripe_run_right.png"},
     // the parallax background

--- a/tutorial_final/js/resources.js
+++ b/tutorial_final/js/resources.js
@@ -17,6 +17,8 @@ game.resources = [
 	{name: "area01_bkg1",         type:"image",	src: "data/img/area01_bkg1.png"},
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	
 	/* 
 	 * Maps. 

--- a/tutorial_step2/js/resources.js
+++ b/tutorial_step2/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	
 	/* 
 	 * Maps. 

--- a/tutorial_step3/js/resources.js
+++ b/tutorial_step3/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	// the main player spritesheet
 	{name: "gripe_run_right",     type:"image",	src: "data/img/sprite/gripe_run_right.png"},
 	/* 

--- a/tutorial_step4/js/resources.js
+++ b/tutorial_step4/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	// the main player spritesheet
 	{name: "gripe_run_right",     type:"image",	src: "data/img/sprite/gripe_run_right.png"},
 	// the parallax background

--- a/tutorial_step5/js/resources.js
+++ b/tutorial_step5/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	// the main player spritesheet
 	{name: "gripe_run_right",     type:"image",	src: "data/img/sprite/gripe_run_right.png"},
 	// the parallax background

--- a/tutorial_step6/js/resources.js
+++ b/tutorial_step6/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	// the main player spritesheet
 	{name: "gripe_run_right",     type:"image",	src: "data/img/sprite/gripe_run_right.png"},
 	// the parallax background

--- a/tutorial_step7/js/resources.js
+++ b/tutorial_step7/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	// the main player spritesheet
 	{name: "gripe_run_right",     type:"image",	src: "data/img/sprite/gripe_run_right.png"},
 	// the parallax background

--- a/tutorial_step8/js/resources.js
+++ b/tutorial_step8/js/resources.js
@@ -4,6 +4,8 @@ game.resources = [
 	 */
 	// our level tileset
 	{name: "area01_level_tiles",  type:"image",	src: "data/img/map/area01_level_tiles.png"},
+	// our metatiles
+	{name: "metatiles32x32",  type:"image", src: "data/img/map/metatiles32x32.png"},
 	// the main player spritesheet
 	{name: "gripe_run_right",     type:"image",	src: "data/img/sprite/gripe_run_right.png"},
 	// the parallax background


### PR DESCRIPTION
Add missing 'metatiles32x32' reference to game resources files in tutorial and tutorial support files to fix the "melonJS: 'metatiles32x32' file for tileset 'metatiles32x32' not found!" error message
