### PR TITLE
Fix .sidebar media query to use correct min-width

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -83,7 +83,7 @@ body {
 .sidebar {
   display: none;
 }
-@media (min-width: 768px) {
+@media (min-width: 992px) {
   .sidebar {
     position: fixed;
     top: 50px;


### PR DESCRIPTION
This PR implements the simplest change to make the tutorial readable on devices with screen widths 768-992px by hiding the sidebar. I was trying to read the page on my phone but the sidebar is a little in the way. 

![sidebar](https://cloud.githubusercontent.com/assets/5579692/8300284/8207996a-198b-11e5-8769-94a668da5f8e.png)

> Increase the min-width from 768px to 992px to match breakpoint for
> medium-sized devices in Bootstrap framework
> 
> Previously the sidebar covered the tutorial text on devices with screen
> widths 768-992px. Now the sidebar is hidden at that screen width.
