### PR TITLE
replaced local version of melonjs with cdn version for compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@ index.css
                     <p>The boilerplate also provides a bunch of default code, but first let's have a look at our
                         js/game.js skeleton:</p>
 
-                    <pre><code>import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+                    <pre><code>import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'
@@ -291,7 +291,7 @@ me.device.onReady( game.onload );
                         display our previously preloaded level, by adding a call to the <b>loadLevel</b> function and
                         our default level name :</p>
 
-                    <pre><code>import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+                    <pre><code>import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'
@@ -363,7 +363,7 @@ export default class PlayScreen extends me.Stage {
                     <p>Then it's time to create our entity, open the `js/entities/entities.js` example file, and let's
                         complete it to match with the following : </p>
 
-                    <pre><code>import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+                    <pre><code>import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 /**
  * Player Entity
@@ -1571,7 +1571,7 @@ loaded() {
                     <p>Notice that we're importing each corresponding entity type from its own file. This will allow for
                         easier maintenance in the future. Go ahead and copy the following code into js/entities/player-entity.js</p>
 
-                    <pre><code>import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+                    <pre><code>import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class PlayerEntity extends me.Entity {

--- a/tutorial_step2/js/entities/HUD.js
+++ b/tutorial_step2/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step2/js/entities/entities.js
+++ b/tutorial_step2/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 /**
  * Player Entity

--- a/tutorial_step2/js/game.js
+++ b/tutorial_step2/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step2/js/screens/play.js
+++ b/tutorial_step2/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step2/js/screens/title.js
+++ b/tutorial_step2/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step3/js/entities/HUD.js
+++ b/tutorial_step3/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step3/js/entities/entities.js
+++ b/tutorial_step3/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 /**
  * Player Entity

--- a/tutorial_step3/js/game.js
+++ b/tutorial_step3/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step3/js/screens/play.js
+++ b/tutorial_step3/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step3/js/screens/title.js
+++ b/tutorial_step3/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step4/js/entities/HUD.js
+++ b/tutorial_step4/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step4/js/entities/entities.js
+++ b/tutorial_step4/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 /**
  * Player Entity

--- a/tutorial_step4/js/game.js
+++ b/tutorial_step4/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step4/js/screens/play.js
+++ b/tutorial_step4/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step4/js/screens/title.js
+++ b/tutorial_step4/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step5/js/entities/HUD.js
+++ b/tutorial_step5/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step5/js/entities/entities.js
+++ b/tutorial_step5/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 let entities = {};
 

--- a/tutorial_step5/js/game.js
+++ b/tutorial_step5/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step5/js/screens/play.js
+++ b/tutorial_step5/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step5/js/screens/title.js
+++ b/tutorial_step5/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step6/js/entities/HUD.js
+++ b/tutorial_step6/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step6/js/entities/entities.js
+++ b/tutorial_step6/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step6/js/game.js
+++ b/tutorial_step6/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step6/js/screens/play.js
+++ b/tutorial_step6/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step6/js/screens/title.js
+++ b/tutorial_step6/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step7/js/entities/HUD.js
+++ b/tutorial_step7/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step7/js/entities/entities.js
+++ b/tutorial_step7/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step7/js/game.js
+++ b/tutorial_step7/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step7/js/screens/play.js
+++ b/tutorial_step7/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step7/js/screens/title.js
+++ b/tutorial_step7/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step8/js/entities/HUD.js
+++ b/tutorial_step8/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step8/js/entities/entities.js
+++ b/tutorial_step8/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step8/js/game.js
+++ b/tutorial_step8/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step8/js/screens/play.js
+++ b/tutorial_step8/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step8/js/screens/title.js
+++ b/tutorial_step8/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleScreen extends me.Stage {

--- a/tutorial_step9/js/entities/HUD.js
+++ b/tutorial_step9/js/entities/HUD.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step9/js/entities/entities.js
+++ b/tutorial_step9/js/entities/entities.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import data from '../data.js'
 

--- a/tutorial_step9/js/game.js
+++ b/tutorial_step9/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_step9/js/screens/play.js
+++ b/tutorial_step9/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/HUD.js'
 import data from '../data.js'

--- a/tutorial_step9/js/screens/title.js
+++ b/tutorial_step9/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export class TitleText extends me.Renderable {

--- a/tutorial_stepz_refactored/js/entities/coin-entity.js
+++ b/tutorial_stepz_refactored/js/entities/coin-entity.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 import data from "../data.js";
 
 

--- a/tutorial_stepz_refactored/js/entities/enemy-entity.js
+++ b/tutorial_stepz_refactored/js/entities/enemy-entity.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class EnemyEntity extends me.Sprite {

--- a/tutorial_stepz_refactored/js/entities/hud/container.js
+++ b/tutorial_stepz_refactored/js/entities/hud/container.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 import ScoreItem from "./score-item.js";
 
 

--- a/tutorial_stepz_refactored/js/entities/hud/score-item.js
+++ b/tutorial_stepz_refactored/js/entities/hud/score-item.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 import data from '../../data.js'
 
 

--- a/tutorial_stepz_refactored/js/entities/title-text.js
+++ b/tutorial_stepz_refactored/js/entities/title-text.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 
 export default class TitleText extends me.Renderable {

--- a/tutorial_stepz_refactored/js/game.js
+++ b/tutorial_stepz_refactored/js/game.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import TitleScreen from './screens/title.js'
 import PlayScreen from './screens/play.js'

--- a/tutorial_stepz_refactored/js/screens/play.js
+++ b/tutorial_stepz_refactored/js/screens/play.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 
 import HUD from '../entities/hud/index.js'
 import data from '../data.js'

--- a/tutorial_stepz_refactored/js/screens/title.js
+++ b/tutorial_stepz_refactored/js/screens/title.js
@@ -1,4 +1,4 @@
-import * as me from '/node_modules/melonjs/dist/melonjs.module.js'
+import * as me from 'https://cdn.jsdelivr.net/npm/melonjs@10.1.0/dist/melonjs.module.js'
 import TitleText from '../entities/title-text.js'
 
 


### PR DESCRIPTION
Noticed the examples weren't working because the absolute path was different on the github.com version versus the local version. I updated them to use a cdn version that way they would resolve.